### PR TITLE
GSoC22: Update Scatter Chart To Use Canvas

### DIFF
--- a/config/data.json
+++ b/config/data.json
@@ -14,7 +14,7 @@
       "description": "Quality Level",
       "chartType": "PIE_CHART",
       "fields": { "x": "quality_label" },
-      "size": [2, 2],
+      "size": [1, 1],
       "priority": 60
     },
     {
@@ -34,6 +34,16 @@
       "fields": { "x": "volatile acidity" },
       "binsCount": 50,
       "size": [1, 1],
+      "priority": 50
+    },
+    {
+      "id": "scatter",
+      "title": "scatter",
+      "description": "scatter",
+      "chartType": "SCATTER_CHART",
+      "fields": { "x": "volatile acidity", "y": "citric acid" },
+      "binsCount": 50,
+      "size": [2, 2],
       "priority": 50
     }
   ]

--- a/source/components/Layout/VisGridView/VisGridItem/VisGridItem.js
+++ b/source/components/Layout/VisGridView/VisGridItem/VisGridItem.js
@@ -74,7 +74,11 @@ VisGridItem.propTypes = {
   layout: PropTypes.shape({
     width: PropTypes.number.isRequired,
     currentCols: PropTypes.number.isRequired,
-  }).isRequired,
+  }),
   fullScreened: PropTypes.bool.isRequired,
   toggleFullScreen: PropTypes.func.isRequired,
+};
+
+VisGridItem.defaultProps = {
+  layout: null,
 };

--- a/source/contexts/DataContext.js
+++ b/source/contexts/DataContext.js
@@ -63,7 +63,7 @@ export default function DataContextProvider({ children }) {
   const addFiltersHandler = (toAddFilters) => {
     const oldFilters = [...filtersRef.current];
     // remove first
-    let newFilters = oldFilters.filter((of) => toAddFilters.some((nf) => !(of.id === nf.id)));
+    let newFilters = oldFilters.filter((of) => toAddFilters.every((nf) => !(of.id === nf.id)));
     // add
     newFilters = [...newFilters, ...toAddFilters];
     // do filter


### PR DESCRIPTION
The current implementation for the scatter chart uses SVG which can be very slow when the data gets big (you can start noticing this with datasets with thousands of points), so I changed the implementation to use the Canvas API which is very fast compared to the SVG

### Performance Using SVG 

![before](https://user-images.githubusercontent.com/30212455/177221238-0031d08c-98c7-4dba-b716-56a340e0a314.gif)

### Performance Using Canvas

![after](https://user-images.githubusercontent.com/30212455/177221249-f8583589-68a1-4f7a-a6ec-7b45fcd885ff.gif)

