### PR TITLE
GSoC 22: Abstract tooltip to be used in different  charts

### DIFF
--- a/config/demo.json
+++ b/config/demo.json
@@ -9,15 +9,6 @@
   "DATA_FORMAT": "csv",
   "VISUALIZATION_VIEW_CONFIGURATION": [
     {
-      "id": "type",
-      "title": "Wine Type",
-      "description": "Wine Type",
-      "chartType": "PIE_CHART",
-      "fields": { "x": "wine_type" },
-      "size": [1, 1],
-      "priority": 50
-    },
-    {
       "id": "quality",
       "title": "Quality Level",
       "description": "Quality Level",
@@ -81,6 +72,15 @@
         "z": "residual sugar"
       },
       "size": [2, 1],
+      "priority": 50
+    },
+    {
+      "id": "type",
+      "title": "Wine Type",
+      "description": "Wine Type",
+      "chartType": "PIE_CHART",
+      "fields": { "x": "wine_type" },
+      "size": [1, 1],
       "priority": 50
     }
   ]

--- a/source/components/VisualTools/Chart/Heatmap.js
+++ b/source/components/VisualTools/Chart/Heatmap.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
 import { numFixed } from '../../../common/utils';
+import createTooltip from '../../partials/tooltip';
 
 function Heatmap(props) {
   const self = useRef();
@@ -67,32 +68,13 @@ function Heatmap(props) {
         .domain(d3.extent(props.data, (d) => d[props.fields.z]));
 
       // create a tooltip
-      const tooltip = d3
-        .select(self.current)
-        .append('div')
-        .style('opacity', 0)
-        .attr('class', 'tooltip')
-        .style('background-color', 'white')
-        .style('border', 'solid')
-        .style('border-width', '2px')
-        .style('border-radius', '5px')
-        .style('padding', '5px');
-
-      // handlers to show or hide tooltip
-      const mouseover = function over() {
-        tooltip.style('opacity', 1);
-        d3.select(this).style('stroke', 'black').style('opacity', 1);
+      const addLabel = (d) => `The ${props.fields.z} of this 
+      cell is: ${numFixed(d.z ? d.z : 0)}`;
+      const offset = {
+        x: 80,
+        y: 0,
       };
-      const mousemove = function move(d) {
-        tooltip
-          .html(`The ${props.fields.z} of this cell is: ${numFixed(d.z ? d.z : 0)}`)
-          .style('left', `${d3.mouse(this)[0] + 70}px`)
-          .style('top', `${d3.mouse(this)[1]}px`);
-      };
-      const mouseleave = function leave() {
-        tooltip.style('opacity', 0);
-        d3.select(this).style('stroke', 'none').style('opacity', 0.8);
-      };
+      const tooltipHandlers = createTooltip(self.current, addLabel, offset);
 
       // Group data by the values of x and y
       // then aggregate to one value using mean
@@ -125,9 +107,8 @@ function Heatmap(props) {
         .style('stroke-width', 4)
         .style('stroke', 'none')
         .style('opacity', 0.8)
-        .on('mouseover', mouseover)
-        .on('mousemove', mousemove)
-        .on('mouseleave', mouseleave)
+        .on('mousemove', tooltipHandlers.mousemove)
+        .on('mouseleave', tooltipHandlers.mouseleave)
         .on('click', (d) => {
           const filters = [
             {

--- a/source/components/VisualTools/Chart/PieChart.js
+++ b/source/components/VisualTools/Chart/PieChart.js
@@ -1,18 +1,16 @@
 import React, { useRef, useEffect } from 'react';
 import * as d3 from 'd3';
 import PropTypes from 'prop-types';
+import createTooltip from '../../partials/tooltip';
 
 function PieChart(props) {
   const self = useRef();
-  const tooltip = useRef();
   const margin = {
     top: 5,
     right: 5,
     bottom: 5,
     left: 5,
   };
-  const pies = useRef();
-  const color = useRef();
   const data = d3
     .nest()
     .key((d) => d[props.fields.x])
@@ -21,27 +19,31 @@ function PieChart(props) {
     .entries(props.data);
 
   const sum = d3.sum(data, (d) => d.value);
+  const pie = d3
+    .pie()
+    .sortValues((a, b) => b - a)
+    .value((d) => d.value);
+
+  const arcs = pie(data);
 
   useEffect(() => {
     setTimeout(() => {
+      // Remove old svg if any
+      d3.select(self.current).select('.tooltip').remove('.tooltip');
+      d3.select(self.current).selectAll('svg').remove('svg');
+
+      // calculate chart dimensions
       const rect = self.current.getBoundingClientRect();
       const innerWidth = rect.width - margin.left - margin.right;
       const innerHeight = rect.height - margin.top - margin.bottom;
       const radius = Math.min(innerWidth, innerHeight) / 2;
-      const pie = d3
-        .pie()
-        .sortValues((a, b) => b - a)
-        .value((d) => d.value);
 
-      const arcs = pie(data);
       const arc = d3.arc().innerRadius(0).outerRadius(radius);
 
-      color.current = d3
+      const color = d3
         .scaleOrdinal()
         .domain(data.map((d) => d.key))
         .range(d3.quantize((t) => d3.interpolateSpectral(t), data.length));
-
-      d3.select(self.current).selectAll('svg').remove('svg');
 
       const svg = d3
         .select(self.current)
@@ -56,36 +58,70 @@ function PieChart(props) {
           `translate(${innerWidth / 2 + margin.left},${innerHeight / 2 + margin.top})`,
         );
 
-      pies.current = viewer
+      if (innerWidth > 500) {
+        const legendG = svg
+          .selectAll('.legend')
+          .data(arcs)
+          .enter()
+          .append('g')
+          .attr('transform', (d, i) => `translate(${innerWidth - 110},${i * 15 + 20})`)
+          .attr('class', 'legend');
+
+        legendG
+          .append('rect') // make a matching color rect
+          .attr('width', 13)
+          .attr('height', 13)
+          .attr('fill', (d, i) => color(i))
+          .attr('stroke', 'grey')
+          .style('stroke-width', '1px');
+
+        legendG
+          .append('text') // add the text
+          .text((d) => `${d.value}  ${d.data.key}`)
+          .style('font-size', 15)
+          .attr('y', 13)
+          .attr('x', 15);
+      }
+
+      // create a tooltip
+      const addLabel = (d) => `Class: ${d.data.key} Count: ${d.data.value} 
+      Percentage: ${d3.format('.0%')(d.data.value / sum)}`;
+      const offset = {
+        x: rect.width / 2 + 20,
+        y: rect.height / 2,
+      };
+      const tooltipHandlers = createTooltip(self.current, addLabel, offset);
+
+      const onClick = (d) => {
+        d.data.selected = !d.data.selected;
+        const values = data.reduce((value, point) => {
+          if (point.selected) value.push(point.key);
+          return value;
+        }, []);
+        if (values.length > 0) {
+          const filter = {
+            id: props.id,
+            title: props.title,
+            field: props.fields.x,
+            operation: 'in',
+            values,
+          };
+          props.filterAdded([filter]);
+        } else {
+          props.filterRemove(props.id);
+        }
+      };
+
+      const pies = viewer
         .selectAll('path')
         .data(arcs)
         .join('path')
         .attr('class', 'slide')
-        .attr('fill', (d) => color.current(d.data.key))
+        .attr('fill', (d) => color(d.data.key))
         .attr('d', arc)
-        .on('click', (d) => {
-          d.data.selected = !d.data.selected;
-          const values = data.reduce((value, point) => {
-            if (point.selected) value.push(point.key);
-            return value;
-          }, []);
-          if (values.length > 0) {
-            const filter = {
-              id: props.id,
-              title: props.title,
-              field: props.fields.x,
-              operation: 'in',
-              values,
-            };
-            props.filterAdded([filter]);
-          } else {
-            props.filterRemove(props.id);
-          }
-        });
-
-      pies.current
-        .append('title')
-        .text((d) => `${d.data.key}:${d.data.value}:${d3.format('.0%')(d.data.value / sum)}`);
+        .on('mousemove', tooltipHandlers.mousemove)
+        .on('mouseleave', tooltipHandlers.mouseleave)
+        .on('click', onClick);
 
       const filters = props.filters.filter((f) => f.id === props.id);
       if (filters.length > 0) {
@@ -95,15 +131,9 @@ function PieChart(props) {
           });
         });
       }
-    }, 100);
-  }, [props.layout]);
-
-  useEffect(() => {
-    setTimeout(() => {
-      const filters = props.filters.filter((f) => f.id === props.id);
       if (filters.length > 0) {
-        pies.current
-          .attr('fill', (d) => (d.data.selected ? color.current(d.data.key) : '#C0C0C0'))
+        pies
+          .attr('fill', (d) => (d.data.selected ? color(d.data.key) : '#C0C0C0'))
           .attr('fill-opacity', (d) => (d.data.selected ? 1 : 0.5))
           .attr('stroke', '#CCCCCC')
           .attr('stroke-width', (d) => (d.data.selected ? 3 : 0));
@@ -111,18 +141,17 @@ function PieChart(props) {
         data.forEach((d) => {
           d.selected = false;
         });
-        pies.current
-          .attr('fill', (d) => color.current(d.data.key))
+        pies
+          .attr('fill', (d) => color(d.data.key))
           .attr('fill-opacity', 1)
           .attr('stroke', 'none');
       }
     }, 100);
-  }, [props.filters, props.layout]);
+  }, [props.layout, props.filters]);
 
   return (
     <div style={{ width: '100%', height: '100%' }}>
       <div id={props.id} ref={self} style={{ width: '100%', height: '100%' }} />
-      <div ref={tooltip} className="tooltip" />
     </div>
   );
 }

--- a/source/components/partials/tooltip.js
+++ b/source/components/partials/tooltip.js
@@ -1,0 +1,40 @@
+import * as d3 from 'd3';
+
+/**
+ * @function createTooltip
+ * @description creates a tooltip dev and mount it to
+ * the chart
+ * @param {*} mount reference to the chart to mount tooltip on
+ * @param {Function} addLabel function to generate text inside tooltip
+ * @param {Object} offset the x and y offset from mouse position to position tooltip
+ * @returns {Object} contains to function mousemove and mouseleave handlers
+ */
+
+function createTooltip(mount, addLabel, offset) {
+  const tooltip = d3
+    .select(mount)
+    .append('div')
+    .style('opacity', 0)
+    .attr('class', 'tooltip')
+    .style('background-color', 'white')
+    .style('border', 'solid')
+    .style('border-width', '2px')
+    .style('border-radius', '5px')
+    .style('padding', '5px');
+
+  const mousemove = function move(d) {
+    tooltip
+      .html(addLabel(d))
+      .style('opacity', 1)
+      .style('left', `${offset.x + d3.mouse(this)[0]}px`)
+      .style('top', `${offset.y + d3.mouse(this)[1]}px`);
+  };
+
+  const mouseleave = function leave() {
+    tooltip.style('opacity', 0);
+  };
+
+  return { mousemove, mouseleave };
+}
+
+export default createTooltip;


### PR DESCRIPTION
This pull request includes the following changes 

## Using the same tooltip across all components to avoid code duplication and for visual consistency
![image](https://user-images.githubusercontent.com/30212455/180837045-d45b7c16-bb25-4425-ba22-6cfdd1146425.png)
![image](https://user-images.githubusercontent.com/30212455/180837095-0eebf644-fad4-4fce-9a29-010d1eef3bb0.png)
![image](https://user-images.githubusercontent.com/30212455/180837293-b91ea4bb-70e0-44ec-b007-41aa933c091c.png)

## Adding a legend to Pie Chart if there is enough space or in full-screen mode
![image](https://user-images.githubusercontent.com/30212455/180837175-fcb4d85e-c175-46ad-93ef-a82cb68a29ec.png)
