### PR TITLE
Gsoc22: Scatter Chart Bug Fix and Adding Vis-Borders Control

### DIFF
--- a/source/components/Layout/VisGridView/VisGridItem/VisGridItemHeader/VisGridItemHeader.js
+++ b/source/components/Layout/VisGridView/VisGridItem/VisGridItemHeader/VisGridItemHeader.js
@@ -14,6 +14,7 @@ function VisGridItemHeader(props) {
       title={props.description}
       style={{
         backgroundColor: color || '#007bff',
+        borderRadius: config?.BORDER_RADIUS ? `${config.BORDER_RADIUS}px` : '0px',
       }}
     >
       <div className="name-header draggable">

--- a/source/components/Layout/VisGridView/VisGridView.js
+++ b/source/components/Layout/VisGridView/VisGridView.js
@@ -100,6 +100,7 @@ function VisGridView({ fullVisScreenHandler, fullScreened }) {
                 border: config?.HIDE_BORDER
                   ? ''
                   : `1px solid ${config?.THEME_COLOR ? config?.THEME_COLOR : '#007bff'}`,
+                borderRadius: config?.BORDER_RADIUS ? `${config.BORDER_RADIUS}px` : '0px',
               }}
             >
               <VisGridItem

--- a/source/components/Settings/Settings.js
+++ b/source/components/Settings/Settings.js
@@ -20,6 +20,7 @@ function Settings() {
   const [color, setColor] = useState(config.THEME_COLOR ? config.THEME_COLOR : '#007bff');
   const [homeUrl, setHomeUrl] = useState(config.HOME_URL);
   const [headerHight, setHeaderHight] = useState(config.HEIGHT_OF_VIS_HEADER);
+  const [hideBorder, setHideBorder] = useState(config?.HIDE_BORDER ? 'Hide' : 'Show');
   const [visMargin, setVisMargin] = useState({
     x: config.MARGIN_OF_GRID_VIEW[0],
     y: config.MARGIN_OF_GRID_VIEW[1],
@@ -48,6 +49,7 @@ function Settings() {
       MARGIN_OF_GRID_VIEW: [Number(visMargin.x), Number(visMargin.y)],
       UNIT_OF_GRID_VIEW: [Number(visSize.x), Number(visSize.y)],
       THEME_COLOR: color,
+      HIDE_BORDER: hideBorder !== 'Show',
     }));
 
     setPending(false);
@@ -84,6 +86,13 @@ function Settings() {
                 <ColumnInput label="Title" value={title} setValue={setTitle} />
                 <ColumnInput label="Data URL" value={url} setValue={setUrl} disabled />
                 <ColumnInput label="Data Format" value={format} setValue={setFormat} disabled />
+                <Form.Group as={Col} className="mb-3">
+                  <Form.Label className="settings-label">Borders</Form.Label>
+                  <Form.Select value={hideBorder} onChange={(e) => setHideBorder(e.target.value)}>
+                    <option>Show</option>
+                    <option>Hide</option>
+                  </Form.Select>
+                </Form.Group>
               </Col>
 
               <Col className="p-0">

--- a/source/components/Settings/Settings.js
+++ b/source/components/Settings/Settings.js
@@ -21,6 +21,9 @@ function Settings() {
   const [homeUrl, setHomeUrl] = useState(config.HOME_URL);
   const [headerHight, setHeaderHight] = useState(config.HEIGHT_OF_VIS_HEADER);
   const [hideBorder, setHideBorder] = useState(config?.HIDE_BORDER ? 'Hide' : 'Show');
+  const [borderRadius, setBorderRadius] = useState(
+    config?.BORDER_RADIUS ? config.BORDER_RADIUS : 0,
+  );
   const [visMargin, setVisMargin] = useState({
     x: config.MARGIN_OF_GRID_VIEW[0],
     y: config.MARGIN_OF_GRID_VIEW[1],
@@ -50,6 +53,7 @@ function Settings() {
       UNIT_OF_GRID_VIEW: [Number(visSize.x), Number(visSize.y)],
       THEME_COLOR: color,
       HIDE_BORDER: hideBorder !== 'Show',
+      BORDER_RADIUS: borderRadius,
     }));
 
     setPending(false);
@@ -104,6 +108,12 @@ function Settings() {
                   setValue={setHeaderHight}
                   type="number"
                   disabled
+                />
+                <ColumnInput
+                  label="Border Radius"
+                  value={borderRadius}
+                  setValue={setBorderRadius}
+                  type="number"
                 />
               </Col>
 

--- a/source/components/VisualTools/Chart/ScatterChart.js
+++ b/source/components/VisualTools/Chart/ScatterChart.js
@@ -23,11 +23,16 @@ export default class ScatterChart extends PureComponent {
   }
 
   componentDidMount() {
+    this.componentDidUpdate();
+  }
+
+  componentDidUpdate() {
     setTimeout(() => {
+      d3.select(this.self.current).selectAll('canvas').remove('canvas');
       d3.select(this.self.current).selectAll('svg').remove('svg');
-      const rect = this.self.current.getBoundingClientRect();
-      const innerWidth = rect.width - this.state.margin.left - this.state.margin.right;
-      const innerHeight = rect.height - this.state.margin.top - this.state.margin.bottom;
+      this.rect = this.self.current.getBoundingClientRect();
+      const innerWidth = this.rect.width - this.state.margin.left - this.state.margin.right;
+      const innerHeight = this.rect.height - this.state.margin.top - this.state.margin.bottom;
 
       this.canvas = d3
         .select(this.self.current)
@@ -40,8 +45,8 @@ export default class ScatterChart extends PureComponent {
       const svg = d3
         .select(this.self.current)
         .append('svg')
-        .attr('width', rect.width)
-        .attr('height', rect.height)
+        .attr('width', this.rect.width)
+        .attr('height', this.rect.height)
         .attr('transform', `translate(${0},${-innerHeight})`);
 
       // create viewer
@@ -71,12 +76,8 @@ export default class ScatterChart extends PureComponent {
 
       viewer.append('g').call(this.brush);
 
-      this.componentDidUpdate();
+      this.draw();
     }, 100);
-  }
-
-  componentDidUpdate() {
-    this.draw();
   }
 
   drawPoint(point) {
@@ -92,9 +93,8 @@ export default class ScatterChart extends PureComponent {
   }
 
   draw() {
-    const rect = this.self.current.getBoundingClientRect();
     this.context = this.canvas.node().getContext('2d');
-    this.context.clearRect(0, 0, rect.width, rect.height);
+    this.context.clearRect(0, 0, this.rect.width, this.rect.height);
     this.context.fillStyle = '#87CEEB';
     this.context.strokeWidth = 1;
     this.context.strokeStyle = '#4682B4';


### PR DESCRIPTION
# Description
This PR contains fixes for the scatter chart as it wasn't responsive to changes from vis settings component, this PR also includes adding some control to vis borders from UI

## Before Fix
![e1](https://user-images.githubusercontent.com/30212455/187037950-3177c686-f68e-4c6c-b646-53a1713c2cfe.gif)

## After
![e2](https://user-images.githubusercontent.com/30212455/187037972-cb5c6a4d-f7ff-44e9-9dcb-9bf30943e0be.gif)

## Hide or Show Borders
![B1](https://user-images.githubusercontent.com/30212455/187037511-e63b90a8-c730-4579-bf3c-5997a394c735.gif)

## Control Borders Radius
![B2](https://user-images.githubusercontent.com/30212455/187037541-9c375446-33a3-40bd-976e-8a489776709e.gif)
