### PR TITLE
GSoC22: Add And Delete Charts From GUI

### DIFF
--- a/source/components/Layout/VisGridView/VisGridItem/VisGridItemControl/VisGridItemControl.js
+++ b/source/components/Layout/VisGridView/VisGridItem/VisGridItemControl/VisGridItemControl.js
@@ -1,15 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Button from 'react-bootstrap/Button';
-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCompressArrowsAlt, faExpandArrowsAlt } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
+import { ConfigContext } from '../../../../../contexts/ConfigContext';
 import VisSettings from '../../../../VisSettings/VisSettings';
 
 // css class
 import './VisGridItemControl.css';
 
 function VisGridItemControl(props) {
+  const { config } = useContext(ConfigContext);
   const [show, setShow] = useState(false);
   let btnFilterRemove;
   if (props.filters.length > 0 && props.filters.find((f) => f.id === props.id)) {
@@ -30,7 +31,12 @@ function VisGridItemControl(props) {
       {(props.hover || show) && (
         <div className="vis-grid-item-control">
           {btnFilterRemove}
-          <VisSettings id={props.id} show={show} setShow={setShow} setHover={props.setHover} />
+          <VisSettings
+            show={show}
+            setShow={setShow}
+            setHover={props.setHover}
+            chartConfig={config.VISUALIZATION_VIEW_CONFIGURATION.find((f) => f.id === props.id)}
+          />
           <Button
             style={{
               background: 'none',

--- a/source/components/Layout/VisGridView/VisGridView.js
+++ b/source/components/Layout/VisGridView/VisGridView.js
@@ -65,7 +65,7 @@ function VisGridView({ fullVisScreenHandler, fullScreened }) {
     return () => {
       window.removeEventListener('resize', debouncedUpdateViewSize);
     };
-  }, [appLayout.currentCols, config.UNIT_OF_GRID_VIEW, config.UNIT_OF_GRID_VIEW]);
+  }, [appLayout.currentCols, config.UNIT_OF_GRID_VIEW, config.UNIT_OF_GRID_VIEW, visConfig]);
 
   useEffect(() => {
     const rect = self.current.getBoundingClientRect();
@@ -103,12 +103,14 @@ function VisGridView({ fullVisScreenHandler, fullScreened }) {
                 borderRadius: config?.BORDER_RADIUS ? `${config.BORDER_RADIUS}px` : '0px',
               }}
             >
-              <VisGridItem
-                layout={appLayout}
-                operation={visConfig.find((vis) => vis.id === item.i)}
-                toggleFullScreen={fullVisScreenHandler}
-                fullScreened={fullScreened}
-              />
+              {visConfig.find((vis) => vis.id === item.i) && (
+                <VisGridItem
+                  layout={appLayout}
+                  operation={visConfig.find((vis) => vis.id === item.i)}
+                  toggleFullScreen={fullVisScreenHandler}
+                  fullScreened={fullScreened}
+                />
+              )}
             </div>
           ))}
         </GridLayout>

--- a/source/components/Settings/Settings.js
+++ b/source/components/Settings/Settings.js
@@ -5,11 +5,12 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import Form from 'react-bootstrap/Form';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
 import { ConfigContext } from '../../contexts/ConfigContext';
 import './Settings.css';
 import ColumnInput from './containers/ColumnInput';
 import RawInput from './containers/RawInput';
+import VisSettings from '../VisSettings/VisSettings';
+import VisTypeComponents, { VisInputDescription } from '../VisualTools/VisTypeComponents';
 
 function Settings() {
   const { config, setConfig } = useContext(ConfigContext);
@@ -21,6 +22,9 @@ function Settings() {
   const [homeUrl, setHomeUrl] = useState(config.HOME_URL);
   const [headerHight, setHeaderHight] = useState(config.HEIGHT_OF_VIS_HEADER);
   const [hideBorder, setHideBorder] = useState(config?.HIDE_BORDER ? 'Hide' : 'Show');
+  const [addChart, setAddChart] = useState('PIE_CHART');
+  const [newVis, setNewVis] = useState({});
+  const [showNewVis, setShowNewVis] = useState(false);
   const [borderRadius, setBorderRadius] = useState(
     config?.BORDER_RADIUS ? config.BORDER_RADIUS : 0,
   );
@@ -54,12 +58,38 @@ function Settings() {
       THEME_COLOR: color,
       HIDE_BORDER: hideBorder !== 'Show',
       BORDER_RADIUS: borderRadius,
+      DATA_RESOURCE_URL: url,
+      DATA_FORMAT: format,
+      VISUALIZATION_VIEW_CONFIGURATION:
+        url !== prevConfig.DATA_RESOURCE_URL || format !== prevConfig.DATA_FORMAT
+          ? []
+          : prevConfig.VISUALIZATION_VIEW_CONFIGURATION,
     }));
 
     setPending(false);
   };
+
+  const handleAdd = (e) => {
+    e.preventDefault();
+    setNewVis({
+      title: '',
+      id: '',
+      description: '',
+      chartType: addChart,
+      size: [1, 1],
+      fields: {
+        x: VisInputDescription[addChart]?.isXArr ? [''] : '',
+        y: VisInputDescription[addChart]?.isYArr ? [''] : '',
+        z: '',
+      },
+    });
+
+    setShow(false);
+    setShowNewVis(true);
+  };
   return (
     <>
+      {showNewVis && <VisSettings chartConfig={newVis} show={showNewVis} setShow={setShowNewVis} />}
       <Button
         size="lg"
         style={{
@@ -88,8 +118,8 @@ function Settings() {
             <Row>
               <Col className="p-0">
                 <ColumnInput label="Title" value={title} setValue={setTitle} />
-                <ColumnInput label="Data URL" value={url} setValue={setUrl} disabled />
-                <ColumnInput label="Data Format" value={format} setValue={setFormat} disabled />
+                <ColumnInput label="Data URL" value={url} setValue={setUrl} />
+                <ColumnInput label="Data Format" value={format} setValue={setFormat} />
                 <Form.Group as={Col} className="mb-3">
                   <Form.Label className="settings-label">Borders</Form.Label>
                   <Form.Select value={hideBorder} onChange={(e) => setHideBorder(e.target.value)}>
@@ -136,6 +166,35 @@ function Settings() {
                 <RawInput label="X" value={visSize.x} setValue={setVisSize} field="x" />
                 <RawInput label="Y" value={visSize.y} setValue={setVisSize} field="y" />
               </Row>
+
+              <Form.Group className="mb-3">
+                <Form.Label className="settings-label">Add New Chart</Form.Label>
+                <div style={{ display: 'flex' }}>
+                  <Form.Select
+                    value={addChart}
+                    onChange={(e) => setAddChart(e.target.value)}
+                    style={{
+                      width: '70%',
+                      marginRight: '10px',
+                    }}
+                  >
+                    {Object.keys(VisTypeComponents).map((key) => (
+                      <option key={key} value={key}>
+                        {VisTypeComponents[key]}
+                      </option>
+                    ))}
+                  </Form.Select>
+                  <Button
+                    style={{
+                      backgroundColor: config.THEME_COLOR ? config.THEME_COLOR : 'rgb(0, 123, 255)',
+                      border: 'none',
+                    }}
+                    onClick={handleAdd}
+                  >
+                    Add Chart
+                  </Button>
+                </div>
+              </Form.Group>
 
               <Row>
                 <Col sm={5}>

--- a/source/components/VisSettings/VisSettings.js
+++ b/source/components/VisSettings/VisSettings.js
@@ -9,10 +9,10 @@ import './VisSettings.css';
 import VisFields from './containers/VisFields';
 
 function VisSettings({
-  id, show, setShow, setHover,
+  chartConfig, show, setShow, setHover,
 }) {
   const { config, setConfig } = useContext(ConfigContext);
-  const chartConfig = config.VISUALIZATION_VIEW_CONFIGURATION.find((f) => f.id === id);
+  // const chartConfig = config.VISUALIZATION_VIEW_CONFIGURATION.find((f) => f.id === id);
   const inputDesc = VisInputDescription[chartConfig.chartType];
 
   const [title, setTitle] = useState(chartConfig.title);
@@ -28,6 +28,7 @@ function VisSettings({
   const [yFields, setYFields] = useState(
     inputDesc?.isYArr ? chartConfig.fields.y : [chartConfig.fields.y],
   );
+  const [zFields, setZFields] = useState([chartConfig.fields?.z]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -55,6 +56,10 @@ function VisSettings({
       chartConfig.fields.y = yFields[0];
     }
 
+    if (inputDesc?.hasZ) {
+      chartConfig.fields.z = zFields[0];
+    }
+
     // add
     newCharts = [...newCharts, chartConfig];
 
@@ -62,12 +67,24 @@ function VisSettings({
       ...prevConfig,
       VISUALIZATION_VIEW_CONFIGURATION: newCharts,
     }));
+
+    // setShow(false);
+  };
+
+  const handleDelete = () => {
+    const oldCharts = config.VISUALIZATION_VIEW_CONFIGURATION;
+    const newCharts = oldCharts.filter((oc) => oc.id !== chartConfig.id);
+    setConfig((prevConfig) => ({
+      ...prevConfig,
+      VISUALIZATION_VIEW_CONFIGURATION: newCharts,
+    }));
+    setShow(false);
   };
 
   const handleClose = () => setShow(false);
   const handleShow = () => {
     setShow(true);
-    setHover(false);
+    if (setHover) setHover(false);
   };
   return (
     <>
@@ -187,17 +204,41 @@ function VisSettings({
                 />
               )}
             </div>
-            <input
-              type="submit"
+            {inputDesc?.hasZ && (
+              <VisFields title="Z" fields={zFields} setFields={setZFields} isArr={false} />
+            )}
+            <div
               style={{
-                marginTop: '10px',
-                width: '50%',
-                backgroundColor: config.THEME_COLOR ? config.THEME_COLOR : 'rgb(0, 123, 255)',
-                border: 'none',
-                color: '#fff',
-                padding: '0.375rem 0.75rem',
+                display: 'flex',
+                justifyContent: 'space-between',
               }}
-            />
+            >
+              <input
+                type="submit"
+                value="Save"
+                style={{
+                  marginTop: '10px',
+                  width: '48%',
+                  backgroundColor: config.THEME_COLOR ? config.THEME_COLOR : 'rgb(0, 123, 255)',
+                  border: 'none',
+                  color: '#fff',
+                  padding: '0.375rem 0.75rem',
+                }}
+              />
+              <Button
+                onClick={handleDelete}
+                variant="danger"
+                style={{
+                  marginTop: '10px',
+                  width: '48%',
+                  border: 'none',
+                  color: '#fff',
+                  padding: '0.375rem 0.75rem',
+                }}
+              >
+                Delete Chart
+              </Button>
+            </div>
           </form>
         </Offcanvas.Body>
       </Offcanvas>
@@ -208,8 +249,12 @@ function VisSettings({
 export default VisSettings;
 
 VisSettings.propTypes = {
-  id: PropTypes.string.isRequired,
+  chartConfig: PropTypes.shape().isRequired,
   show: PropTypes.bool.isRequired,
   setShow: PropTypes.func.isRequired,
-  setHover: PropTypes.func.isRequired,
+  setHover: PropTypes.func,
+};
+
+VisSettings.defaultProps = {
+  setHover: null,
 };

--- a/source/components/VisualTools/VisTypeComponents.js
+++ b/source/components/VisualTools/VisTypeComponents.js
@@ -68,6 +68,7 @@ const VisInputDescription = {
   HEATMAP: {
     hasX: true,
     hasY: true,
+    hasZ: true,
     isXArr: false,
     isYArr: false,
   },

--- a/source/contexts/DataContext.js
+++ b/source/contexts/DataContext.js
@@ -127,7 +127,7 @@ export default function DataContextProvider({ children }) {
       addFiltersHandler,
       removeFiltersHandler,
     }),
-    [filters, loading, dataError],
+    [filters, loading, dataError, data, filteredData],
   );
 
   return <DataContext.Provider value={memoData}>{children}</DataContext.Provider>;


### PR DESCRIPTION
# Description
This PR is for competing the settings and Vis-settings components. The implemented features are related to adding and removing charts directly from GUI instead of using the config file

## Deleting Charts
![delete_chart](https://user-images.githubusercontent.com/30212455/188221580-2445105e-9b07-4e51-9fb6-7da55247592f.gif)

## Adding Charts
![add_chart](https://user-images.githubusercontent.com/30212455/188221783-fd122bfa-312b-42ad-ba95-5f760350290c.gif)

## Changing data URL source 
Note: when changing data URL source or data type all the previous charts will be deleted automatically because they aren't valid anymore and the user can add new charts using the settings board

![change_url](https://user-images.githubusercontent.com/30212455/188223159-31912ffa-3b1e-49c5-bad9-991d025af12f.gif)
![new_dashboard](https://user-images.githubusercontent.com/30212455/188223176-065122fd-3527-4a21-81dd-1638c6693ac0.gif)

